### PR TITLE
add an install button for the chrome extension

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -71,7 +71,8 @@
         "$"         : true,
         "respoke"   : true,
         "App"       : true,
-        "sinon"     : true
+        "sinon"     : true,
+        "chrome"    : true
     }
 }
 

--- a/app/css/_shared.styl
+++ b/app/css/_shared.styl
@@ -632,3 +632,25 @@ body {
 .right .github-fork-ribbon {
     background-color: #3b79b4;
 }
+
+.screen-share-instructions {
+    text-align: center;
+}
+
+.screen-share-instructions button {
+    -webkit-appearance: none;
+    background-color: $accentColor;
+    border: none;
+    border-radius: .5rem;
+    color: #fff;
+    cursor: pointer;
+    flex: 0 5rem;
+    transition: background-color .2s;
+
+    &:hover {
+        background-color: $accentHoverColor;
+    }
+    padding: 1.2rem;
+    font-size: 1rem;
+    margin-top: 1.5rem;
+}

--- a/app/modules/screen-sharing/controllers/AuthenticationCtrl.js
+++ b/app/modules/screen-sharing/controllers/AuthenticationCtrl.js
@@ -31,7 +31,8 @@ App.controllers.authenticationCtrl = (function ($, App) {
         function clickExtension(e){
             e.preventDefault();
             chrome.webstore.install('https://chrome.google.com/webstore/detail/jlpojfookfonjolaeofpibngfpnnflne', function(){
-                console.log('Successfully installed Chrome Extension');
+                console.log('Successfully installed Chrome Extension, reloading page');
+                window.location.reload();
             }, function(err){
                 console.log('Error installing extension in chrome', err);
             });

--- a/app/modules/screen-sharing/controllers/AuthenticationCtrl.js
+++ b/app/modules/screen-sharing/controllers/AuthenticationCtrl.js
@@ -28,6 +28,15 @@ App.controllers.authenticationCtrl = (function ($, App) {
             desc = null;
         }
 
+        function clickExtension(e){
+            e.preventDefault();
+            chrome.webstore.install('https://chrome.google.com/webstore/detail/jlpojfookfonjolaeofpibngfpnnflne', function(){
+                console.log('Successfully installed Chrome Extension');
+            }, function(err){
+                console.log('Error installing extension in chrome', err);
+            });
+        }
+
         // Renders the authentication form
         function renderForm () {
             $el = $.helpers.insertTemplate({
@@ -37,9 +46,15 @@ App.controllers.authenticationCtrl = (function ($, App) {
                 bind: {
                     '.cbl-name': {
                         'submit': submitName
+                    },
+                    '.screen-share-instructions button': {
+                        'click': clickExtension
                     }
                 }
             });
+            if (!respoke.needsChromeExtension) {
+                $el.find('.screen-share-instructions').remove();
+            }
         }
 
         // Initializes the controller

--- a/app/modules/screen-sharing/controllers/MainCtrl.js
+++ b/app/modules/screen-sharing/controllers/MainCtrl.js
@@ -131,7 +131,7 @@ App.controllers.screenShareCtrl = (function ($, App) {
 
             // Remove the endpoint from the buddy list
             ctrl.buddyList.removeMember(e.connection.endpointId);
-            
+
         }
 
         // A callback when a member joins the group

--- a/app/modules/screen-sharing/index.html
+++ b/app/modules/screen-sharing/index.html
@@ -73,7 +73,7 @@
 
             <div class="screen-share-instructions">
                 <p class="cbl-instructions">
-                    Please install the required extension to enable screensharing
+                    Please install the required extension to enable screensharing; Please note the page will refresh after installation.
                 </p>
                 <button id="installExtension">Install</button>
             </div>

--- a/app/modules/screen-sharing/index.html
+++ b/app/modules/screen-sharing/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, minimal-ui">
     <title>Screen Sharing</title>
     <link rel="stylesheet" href="../../css/video-call.css">
+    <link rel="chrome-webstore-item" href="https://chrome.google.com/webstore/detail/jlpojfookfonjolaeofpibngfpnnflne">
 </head>
 <!-- <body class="popup-active"> -->
 <body>
@@ -67,8 +68,15 @@
             </p>
             <p>
             This example illustrates the use of the <a href="https://docs.respoke.io/js-library/respoke.Endpoint.html#startScreenShare" target="_blank">startScreenShare</a> method of the <a href="https://docs.respoke.io/js-library/respoke.Endpoint.html" target="_blank">Endpoint</a> object. This method returns a <a href="https://docs.respoke.io/js-library/respoke.Call.html" target="_blank">Call</a> object which acts as your interface into the WebRTC call and gives you events to notify you about call actions such as when audio is muted or the connection is terminated.
-            </p> 
+            </p>
             <hr/>
+
+            <div class="screen-share-instructions">
+                <p class="cbl-instructions">
+                    Please install the required extension to enable screensharing
+                </p>
+                <button id="installExtension">Install</button>
+            </div>
 
             <p class="cbl-instructions">
                 Enter your name to see a list of all others on this page right now.
@@ -97,7 +105,7 @@
         <header class="group-chat__header">
             <button class="group-list-open">View Buddies</button>
             <div class="group-chat__header__me">
-                
+
             </div>
         </header>
 

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -48,7 +48,7 @@ module.exports = function (grunt) {
             options: {
                 force: true,
                 jshintrc: './.jshintrc',
-                ignores: ['app/js/lib/md5.js']
+                ignores: ['app/js/lib/md5.js', 'app/js/transporter/**/*.js']
             }
         },
 
@@ -74,7 +74,8 @@ module.exports = function (grunt) {
                 files: [
                     'app/js/**/*.js',
                     'test/**/*.js',
-                    'app/modules/**/*.js'
+                    'app/modules/**/*.js',
+                    '!app/js/transporter/**/*.js'
                 ],
                 tasks: ['jshint', 'test', 'injector', 'jscs']
             },


### PR DESCRIPTION
Inline install the chrome extension, hide the button and blerb to install if you're not chrome OR you don't need the chrome extension as you already have it...

We could stop them submitting the form IF they're in Chrome without the plugin?

Not sure what to do in the checks to see if the install was successful or not except console.log....