### PR TITLE
cleaning up package.json, removing global install of bower

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,45 +1,44 @@
 {
-  "name": "digium-respoke",
-  "version": "0.0.0",
-  "description": "",
+  "name": "web-examples",
+  "version": "1.0.0",
+  "description": "Examples of using Respoke in the browser",
   "main": "gruntfile.js",
   "directories": {
     "test": "test"
   },
   "scripts": {
+    "start": "grunt server",
+    "build": "grunt build",
+    "publish": "grunt publish",
     "test": "grunt test",
-    "install": "npm install -g bower && bower install"
+    "postinstall": "bower install"
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/appendto/digium-respoke-applets.git"
+    "url": "git://github.com/respoke/web-examples.git"
   },
-  "authors": [
-    "Tyson Cadenhead <tcadenhead@appendto.com>",
-    "Nicholas Cloud <ncloud@appendto.com>"
-  ],
-  "license": "ISC",
+  "license": "MIT",
   "bugs": {
-    "url": "https://github.com/appendto/digium-respoke-applets/issues"
+    "url": "https://github.com/respoke/web-examples/issues"
   },
-  "homepage": "https://github.com/appendto/digium-respoke-applets",
+  "homepage": "https://github.com/respoke/web-examples",
   "dependencies": {
-    "grunt": "~0.4.5",
-    "grunt-express": "~1.4.1",
+    "bower": "^1.3.12",
     "express": "~4.9.0",
-    "grunt-contrib-connect": "~0.8.0",
-    "grunt-mocha": "~0.4.11",
-    "grunt-contrib-jshint": "~0.10.0",
-    "grunt-contrib-requirejs": "~0.4.4",
-    "underscore": "~1.7.0"
-  },
-  "devDependencies": {
+    "grunt": "~0.4.5",
     "grunt-autoprefixer": "^1.0.1",
     "grunt-browser-sync": "~1.3.6",
+    "grunt-cli": "^0.1.13",
+    "grunt-contrib-connect": "~0.8.0",
     "grunt-contrib-cssmin": "~0.10.0",
+    "grunt-contrib-jshint": "~0.10.0",
+    "grunt-contrib-requirejs": "~0.4.4",
     "grunt-contrib-stylus": "^0.19.0",
+    "grunt-express": "~1.4.1",
     "grunt-gh-pages": "^0.9.1",
     "grunt-injector": "^0.6.0",
-    "grunt-jscs": "~0.7.1"
+    "grunt-jscs": "~0.7.1",
+    "grunt-mocha": "~0.4.11",
+    "underscore": "~1.7.0"
   }
 }


### PR DESCRIPTION
- **set version to a real version**
- **set name to the real name**
- **removed global bower install from `install` script.** don't mess with my global state! I set `bower` and `grunt-cli` to be local dependencies so that the `test` script and the `postinstall` script work regardless of whether you have these installed globally or not
- **changed `install` script to `postinstall` script**. This is makes more sense given the nature of what we're doing in the script
- **changed repo, bugs, and homepage urls to correct urls**
- **removed authors**
- **set license to `MIT` license from `ISC`**
- **moved devDependencies to dependencies**. There is no need for the discrepancy on a non-lib package
- **added npm scripts for the grunt tasks listed in README**